### PR TITLE
Removed what credentials are needed to speak

### DIFF
--- a/_pssaturday/speakers.md
+++ b/_pssaturday/speakers.md
@@ -43,11 +43,3 @@ We started accepting speakers' submissions in mid-April and we'll close the subm
  Our goal is to provide unique and informative sessions that not only educate but engage our attendees. The Raleigh Triangle PowerShell group has always had a stellar lineup of local and national speakers and we expect the same for our one day event.
 
 Our group is known for delivering great content as well as being super friendly and welcoming to all members and all skill levels. We are looking to reproduce the small community feel of our meetings in the full day setting of this conference. Our speakers love us because we put a lot of effort into helping speakers do the best they can to be successful.
-
-### What credentials are needed to be a speaker?
-
-This event is open to speakers of all skill levels and this is an excellent opportunity to get experience in presenting content to an audience. We are very happy to work with first-time speakers as long as your topic is relevant to the information topics  defined for our event. All you need is a passion for PowerShell and an interesting topic. If you are wondering if you can do this, you can!
-
-The main thing our speakers need to be selected is a complete idea that will engage an audience. The audience will be a mix of beginner, intermediate and advanced PowerShell users spread across many different areas of IT. Talks should be mostly code and demos rather then slides. It is certainly ok to use slides, but we would prefer to have as much live demo material and interactions between speakers and participants as possible. Recorded video is also acceptable as backups to live demos.
-
-You can find much more info about the topic selection process and speaker requirements at the official site for submitting topics: https://www.papercall.io/rtpsug-pssaturday


### PR DESCRIPTION
"What Credentials are needed to be a speaker" is just a reworded version of "what does it take to be a speaker at the conference."

The pull is to remove it but a rewrite would work as well.